### PR TITLE
Add web app for Austrian EPEX spot prices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# codex-trial
+# EPEX Spot Preis Dashboard für Österreich
+
+Eine kleine Flask-Webanwendung, die die aktuellen österreichischen EPEX Spot Day-Ahead Preise über die [aWATTar API](https://www.awattar.de/services/api) lädt und interaktiv in einem Chart.js Diagramm darstellt.
+
+## Voraussetzungen
+
+- Python 3.12 (oder kompatibel)
+- Ein virtuelles Python-Umfeld wird empfohlen
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Entwicklung starten
+
+```bash
+flask --app app run --debug
+```
+
+Die Anwendung steht anschließend unter <http://127.0.0.1:5000> zur Verfügung.
+
+## Tests
+
+Aktuell gibt es keine automatisierten Tests. Die wichtigsten Funktionstests erfolgen manuell durch Aufruf der Weboberfläche und Prüfung der ausgegebenen Daten.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,78 @@
+"""Flask web application to display Austrian EPEX spot prices."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any, Dict, List
+from zoneinfo import ZoneInfo
+
+import requests
+from flask import Flask, jsonify, render_template
+
+
+APP_TZ = ZoneInfo("Europe/Vienna")
+AWATTAR_API_URL = "https://api.awattar.at/v1/marketdata"
+
+def _get_today_range() -> tuple[datetime, datetime]:
+    """Return the start and end timestamps for the current day in Vienna time."""
+    now = datetime.now(APP_TZ)
+    start = datetime(year=now.year, month=now.month, day=now.day, tzinfo=APP_TZ)
+    end = start + timedelta(days=1)
+    return start, end
+
+def _epoch_ms(dt: datetime) -> int:
+    return int(dt.timestamp() * 1000)
+
+def fetch_epex_prices(start: datetime | None = None, end: datetime | None = None) -> List[Dict[str, Any]]:
+    """Fetch Austrian EPEX spot prices from the aWATTar market data API."""
+    start_dt, end_dt = start, end
+    if start_dt is None or end_dt is None:
+        start_dt, end_dt = _get_today_range()
+
+    params = {"start": _epoch_ms(start_dt), "end": _epoch_ms(end_dt)}
+    response = requests.get(AWATTAR_API_URL, params=params, timeout=10)
+    response.raise_for_status()
+    payload = response.json()
+
+    prices: List[Dict[str, Any]] = []
+    for entry in payload.get("data", []):
+        start_ts = entry.get("start_timestamp")
+        market_price = entry.get("marketprice")
+        unit = entry.get("unit")
+        if start_ts is None or market_price is None:
+            continue
+
+        start_time = datetime.fromtimestamp(start_ts / 1000, APP_TZ)
+
+        prices.append(
+            {
+                "time": start_time.isoformat(),
+                "price": market_price,
+                "unit": unit or "EUR/MWh",
+            }
+        )
+
+    return prices
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+
+    @app.route("/")
+    def index() -> str:
+        return render_template("index.html")
+
+    @app.route("/api/prices")
+    def api_prices() -> Any:
+        try:
+            prices = fetch_epex_prices()
+            return jsonify({"prices": prices})
+        except requests.RequestException as exc:  # pragma: no cover - network error path
+            return jsonify({"error": str(exc)}), 502
+
+    return app
+
+
+app = create_app()
+
+if __name__ == "__main__":
+    app.run(debug=True, host="0.0.0.0", port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask==3.0.3
+requests==2.32.3

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,0 +1,55 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Segoe UI", Roboto, sans-serif;
+  line-height: 1.5;
+}
+
+body {
+  margin: 0;
+  padding: 0 1.5rem 2rem;
+  background: var(--background, #f7f7f7);
+}
+
+header {
+  text-align: center;
+  padding: 2rem 0 1rem;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 2.4vw + 1rem, 2.8rem);
+}
+
+main {
+  display: flex;
+  justify-content: center;
+}
+
+.chart-section {
+  width: min(900px, 100%);
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.08);
+}
+
+canvas {
+  width: 100% !important;
+  height: auto !important;
+}
+
+.status {
+  margin-top: 1rem;
+  text-align: center;
+  font-weight: 500;
+}
+
+footer {
+  text-align: center;
+  margin-top: 2rem;
+  color: #555;
+}
+
+footer a {
+  color: inherit;
+}

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,0 +1,89 @@
+async function loadPrices() {
+  const statusEl = document.getElementById('status');
+  try {
+    statusEl.textContent = 'Lade Preisdaten...';
+    const response = await fetch('/api/prices');
+    if (!response.ok) {
+      throw new Error(`Fehler beim Laden: ${response.status}`);
+    }
+
+    const payload = await response.json();
+    const prices = payload.prices || [];
+    if (!prices.length) {
+      statusEl.textContent = 'Keine Preisdaten verfügbar.';
+      return;
+    }
+
+    const unit = prices[0].unit || 'EUR/MWh';
+    const labels = prices.map((entry) => new Date(entry.time).toLocaleString('de-AT', {
+      hour: '2-digit',
+      minute: '2-digit',
+      day: '2-digit',
+      month: '2-digit'
+    }));
+
+    const data = prices.map((entry) => entry.price);
+
+    const ctx = document.getElementById('priceChart');
+    const gradient = ctx.getContext('2d').createLinearGradient(0, 0, 0, 400);
+    gradient.addColorStop(0, 'rgba(0, 134, 255, 0.4)');
+    gradient.addColorStop(1, 'rgba(0, 134, 255, 0.05)');
+
+    new Chart(ctx, {
+      type: 'line',
+      data: {
+        labels,
+        datasets: [{
+          label: `Preis (${unit})`,
+          data,
+          fill: true,
+          backgroundColor: gradient,
+          borderColor: 'rgba(0, 134, 255, 1)',
+          tension: 0.3,
+          pointRadius: 3,
+          pointHoverRadius: 5
+        }]
+      },
+      options: {
+        responsive: true,
+        scales: {
+          x: {
+            ticks: {
+              maxRotation: 0,
+              autoSkip: true
+            }
+          },
+          y: {
+            title: {
+              display: true,
+              text: unit
+            }
+          }
+        },
+        interaction: {
+          mode: 'index',
+          intersect: false
+        },
+        plugins: {
+          tooltip: {
+            callbacks: {
+              label: function (context) {
+                const priceValue = context.parsed.y;
+                return ` ${priceValue.toFixed(2)} ${unit}`;
+              }
+            }
+          }
+        }
+      }
+    });
+
+    const minPrice = Math.min(...data);
+    const maxPrice = Math.max(...data);
+    statusEl.textContent = `Zeitraum: ${labels[0]} – ${labels[labels.length - 1]} | Min: ${minPrice.toFixed(2)} ${unit} | Max: ${maxPrice.toFixed(2)} ${unit}`;
+  } catch (error) {
+    console.error(error);
+    statusEl.textContent = 'Es ist ein Fehler beim Laden der Daten aufgetreten.';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', loadPrices);

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>EPEX Spot Preise Österreich</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js" integrity="sha256-ZHT5oXbi3Bt75/WtXu5I5gLDSvAXHnsh+H1W4Lx43rs=" crossorigin="anonymous"></script>
+  </head>
+  <body>
+    <header>
+      <h1>Aktuelle EPEX Spot Preise für Österreich</h1>
+      <p>Die Daten werden direkt aus der aWATTar Schnittstelle geladen, welche die stündlichen EPEX Spot Day-Ahead Preise für Österreich bereitstellt.</p>
+    </header>
+
+    <main>
+      <section class="chart-section">
+        <canvas id="priceChart" aria-label="Stündliche EPEX Spot Preise" role="img"></canvas>
+        <div id="status" class="status"></div>
+      </section>
+    </main>
+
+    <footer>
+      <small>Datenquelle: <a href="https://www.awattar.de/services/api" target="_blank" rel="noopener">aWATTar API</a></small>
+    </footer>
+
+    <script src="{{ url_for('static', filename='js/app.js') }}"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a Flask backend that proxies Austrian EPEX spot prices via the aWATTar API
- serve an interactive Chart.js frontend to visualise hourly prices and show key stats
- document setup instructions and dependencies for running the dashboard locally

## Testing
- python -m compileall app.py static/js/app.js

------
https://chatgpt.com/codex/tasks/task_e_68d40ce0d1c88322bf2e6af6c5e6abb1